### PR TITLE
Add take request of benhylau for cycle ending on Dec 15

### DIFF
--- a/take.md
+++ b/take.md
@@ -4,6 +4,6 @@
 
 | GitHub Handle | ETH Address                                  | May 26 | Jun 9 | Dec 15 | Dec 29 |
 |:-------------:|:--------------------------------------------:|:------:|:-----:|:------:|:------:|
-| @benhylau     | `0x53aE563fCB501221FC11EFDD05B96Ce7e1c350C0` |   0.28 |  0.08 |        |        |
+| @benhylau     | `0x53aE563fCB501221FC11EFDD05B96Ce7e1c350C0` |   0.28 |  0.08 |   1.30 |        |
 | @Shrinks99    | `0x8763F4E7be6103D430FA54680Ce6A40F444F1678` |        |       |        |        |
 | @darkdrgn2k   | `0xcc9098a752a1780152f204ec8188ab27ecc461db` |   0.74 |  0.32 |        |        |


### PR DESCRIPTION
This Take is for work since June 9 since we stopped the process while busy on other things. I have been slowly working on features as needed and when I could find time.

## Website

- Took @patcon's advice and ported [Mozilla's open-leadership-training-series](https://mozilla.github.io/open-leadership-training-series/) to build course website in https://github.com/tomeshnet/p2p-internet-workshop/pull/65, mostly addressing https://github.com/tomeshnet/p2p-internet-workshop/issues/38 but not closing yet because the node configuration needs better documentation
- Made [course assets](https://github.com/tomeshnet/p2p-internet-workshop/releases) and [course website](https://tomeshnet.github.io/p2p-internet-workshop/), auto-deployed on tag by Travis CI in https://github.com/tomeshnet/p2p-internet-workshop/pull/52 https://github.com/tomeshnet/p2p-internet-workshop/pull/53 https://github.com/tomeshnet/p2p-internet-workshop/pull/54 https://github.com/tomeshnet/p2p-internet-workshop/pull/64, closes https://github.com/tomeshnet/p2p-internet-workshop/issues/63

## SSB

- Made first version of SSB worksheet used at dweb https://github.com/tomeshnet/p2p-internet-workshop/commits/dweb this should be iterated on when Patchfoo UI becomes available, the UX flow could be a lot since it now only interacts with sbot in CLI

## Mesh Orange

- Mesh Orange downsizing to make workshop image work on Raspberry Pi 3B+ (hardware we have at dweb), see Aug 1 commits here https://github.com/benhylau/mesh-orange/commits/rpi-3-b-plus-workshop but not the long-term solution we want
- A series of investigations and discussions into how to address this general image size problem on a ramdisk system... the current approach being to use "vanilla" Mesh Orange (which fits on both 3B and 3B+) and then install all deb dependencies on boot