### PR TITLE
Add take request of shrinks99 for cycle ending on Mar 9 

### DIFF
--- a/take.md
+++ b/take.md
@@ -2,8 +2,8 @@
 
 **Current Grant Pool:** [0xc005018f06E328c145331C1b17a03Aba4d7D7E8c](https://etherscan.io/address/0xc005018f06E328c145331C1b17a03Aba4d7D7E8c)
 
-| GitHub Handle | ETH Address                                  | May 26 | Jun 9 | Dec 15 | Dec 29 |
-|:-------------:|:--------------------------------------------:|:------:|:-----:|:------:|:------:|
-| @benhylau     | `0x53aE563fCB501221FC11EFDD05B96Ce7e1c350C0` |   0.28 |  0.08 |   1.30 |        |
-| @Shrinks99    | `0x8763F4E7be6103D430FA54680Ce6A40F444F1678` |        |       |        |        |
-| @darkdrgn2k   | `0xcc9098a752a1780152f204ec8188ab27ecc461db` |   0.74 |  0.32 |  0.68  |        |
+| GitHub Handle | ETH Address                                  | May 26 | Jun 9 | Dec 15 | Dec 29 | Mar 9 |
+|:-------------:|:--------------------------------------------:|:------:|:-----:|:------:|:------:|:-----:|
+| @benhylau     | `0x53aE563fCB501221FC11EFDD05B96Ce7e1c350C0` |   0.28 |  0.08 |   1.30 |        |       |
+| @Shrinks99    | `0x8763F4E7be6103D430FA54680Ce6A40F444F1678` |        |       |        |        |  1.30 |
+| @darkdrgn2k   | `0xcc9098a752a1780152f204ec8188ab27ecc461db` |   0.74 |  0.32 |  0.68  |        |       |

--- a/take.md
+++ b/take.md
@@ -2,8 +2,8 @@
 
 **Current Grant Pool:** [0xc005018f06E328c145331C1b17a03Aba4d7D7E8c](https://etherscan.io/address/0xc005018f06E328c145331C1b17a03Aba4d7D7E8c)
 
-| GitHub Handle | ETH Address                                  | May 26 | Jun 9 | Dec 15 | Dec 29 | Mar 9 |
-|:-------------:|:--------------------------------------------:|:------:|:-----:|:------:|:------:|:-----:|
-| @benhylau     | `0x53aE563fCB501221FC11EFDD05B96Ce7e1c350C0` |   0.28 |  0.08 |   1.30 |        |       |
-| @Shrinks99    | `0x8763F4E7be6103D430FA54680Ce6A40F444F1678` |        |       |        |        |  1.30 |
-| @darkdrgn2k   | `0xcc9098a752a1780152f204ec8188ab27ecc461db` |   0.74 |  0.32 |  0.68  |        |       |
+| GitHub Handle | ETH Address                                  | May 26 | Jun 9 | Dec 15 | Mar 9 |
+|:-------------:|:--------------------------------------------:|:------:|:-----:|:------:|:-----:|
+| @benhylau     | `0x53aE563fCB501221FC11EFDD05B96Ce7e1c350C0` |   0.28 |  0.08 |   1.30 |       |
+| @Shrinks99    | `0x8763F4E7be6103D430FA54680Ce6A40F444F1678` |        |       |        |  1.30 |
+| @darkdrgn2k   | `0xcc9098a752a1780152f204ec8188ab27ecc461db` |   0.74 |  0.32 |  0.68  |       |


### PR DESCRIPTION
This take is for work done from December 18, 2018 – March 1st, 2019.  It encompasses the full redesign and content overhaul done on the current workshop modules and updates to the course website.

For a full list of what was changed and what I did please see [the version 0.12 release notes](https://github.com/tomeshnet/p2p-internet-workshop/releases/tag/v0.12).