### PR TITLE
Update take.md

### DIFF
--- a/take.md
+++ b/take.md
@@ -7,3 +7,5 @@
 | @benhylau     | `0x53aE563fCB501221FC11EFDD05B96Ce7e1c350C0` |   0.28 |  0.08 |   1.30 |       |
 | @Shrinks99    | `0x8763F4E7be6103D430FA54680Ce6A40F444F1678` |        |       |        |  1.30 |
 | @darkdrgn2k   | `0xcc9098a752a1780152f204ec8188ab27ecc461db` |   0.74 |  0.32 |  0.68  |       |
+
+On September 19, 2022, remaining balance of `2.5505 ETH` was sent to support DWeb Camp Brazil 2023 (https://gitcoin.co/grants/5845/dweb-camp-brazil) since deliverables were mostly completed, and there has been no activity in the repo for 4 years.

--- a/take.md
+++ b/take.md
@@ -8,4 +8,4 @@
 | @Shrinks99    | `0x8763F4E7be6103D430FA54680Ce6A40F444F1678` |        |       |        |  1.30 |
 | @darkdrgn2k   | `0xcc9098a752a1780152f204ec8188ab27ecc461db` |   0.74 |  0.32 |  0.68  |       |
 
-On September 19, 2022, remaining balance of `2.5505 ETH` was sent to support DWeb Camp Brazil 2023 (https://gitcoin.co/grants/5845/dweb-camp-brazil) since deliverables were mostly completed, and there has been no activity in the repo for 4 years.
+On September 19, 2022, remaining balance of `2.5505 ETH` was sent to support DWeb Camp Brazil 2023 (https://gitcoin.co/grants/5845/dweb-camp-brazil) via Gitcoin GR15 (https://etherscan.io/tx/0x86f43fd54ec89d37107cc8f31b305012d420ce14c07f3dfe7619a860305f1515) since deliverables were mostly completed, and there has been no activity in the repo for 4 years.


### PR DESCRIPTION
This concludes the project by sending remaining balance of 2.5505 ETH in the pool to support DWeb Camp Brazil 2023 via Gitcoin GR15.

- https://gitcoin.co/grants/5845/dweb-camp-brazil
- https://etherscan.io/tx/0x86f43fd54ec89d37107cc8f31b305012d420ce14c07f3dfe7619a860305f1515